### PR TITLE
Refactoring, support pinning multiple tabs

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,10 +2,12 @@
   "manifest_version": 2,
   "name": "Tab Pinner (Keyboard Shortcuts)",
   "description": "Pin or Unpin a tab easily from the keyboard.",
-  "version": "1.2"
+  "version": "1.2",
   "background": {
     "persistent": false,
-    "scripts": [ "tab_pinner.js" ]
+    "scripts": [
+      "tab_pinner.js"
+    ]
   },
   "commands": {
     "tab_pinner_pin_all_tabs": {
@@ -29,5 +31,5 @@
     "16": "pin_16.png",
     "48": "pin_48.png"
   },
-  "permissions": [],
+  "permissions": []
 }

--- a/tab_pinner.js
+++ b/tab_pinner.js
@@ -1,32 +1,75 @@
 // Copyright (c) 2015 Brandon Buck, All Rights Reserved
 
-var PIN_UNPIN_TAB = "tab_pinner_pin_unpin_tab",
-    UNPIN_ALL = "tab_pinner_unpin_all_tabs",
-    PIN_ALL = "tab_pinner_pin_all_tabs";
-    
-var forEachTab = function(fn) {
-  chrome.windows.getCurrent({populate: true}, function(curWindow) {
-    curWindow.tabs.forEach(fn);
-  });
-};
+const PIN_UNPIN_TAB = "tab_pinner_pin_unpin_tab",
+  UNPIN_ALL = "tab_pinner_unpin_all_tabs",
+  PIN_ALL = "tab_pinner_pin_all_tabs";
 
-chrome.commands.onCommand.addListener(function(command) {
-  if (command === PIN_UNPIN_TAB) {
-    forEachTab(function(tab) {
-      if (tab.active) {
-        chrome.tabs.update(tab.id, {pinned: !tab.pinned});
-      }
-    });
-  } else if (command === UNPIN_ALL) {
-    forEachTab(function(tab) {
-      chrome.tabs.update(tab.id, {pinned: false});
-    });
-  } else if (command === PIN_ALL) {
-    forEachTab(function(tab) {
-      chrome.tabs.update(tab.id, {pinned: true});
-    });
-  } else {
-    return;
+/**
+ * Sets all given tabs to the given pinned state.
+ *
+ * @param {Array} tabs The tabs to set the pinned state of.
+ * @param {boolean} pinned The pinned state to set the tabs to.
+ */
+function setTabsPinnedState(tabs, pinned) {
+  if (!pinned) {
+    // Reverse the order so that the first tab is the last tab to be unpinned.
+    // This keeps the tab order the same when unpinning.
+    tabs.reverse();
+  }
+  tabs.forEach((tab) => chrome.tabs.update(tab.id, { pinned: pinned }));
+}
+
+/**
+ * Toggles the pinned state of the given tabs. If any of the tabs are unpinned, pin them. Otherwise, unpin them.
+ *
+ * @param {Array} tabs The tabs to toggle the pinned state of.
+ */
+function togglePins(tabs) {
+  // If any tab is unpinned, pin all tabs
+  const hasUnpinnedTabs = tabs.some((tab) => !tab.pinned);
+  setTabsPinnedState(tabs, hasUnpinnedTabs);
+}
+
+/**
+ * Runs the given function with all tabs in the current window.
+ *
+ * @param {Function} fn The function to run with all tabs.
+ */
+function withAllTabs(fn) {
+  chrome.windows.getCurrent({ populate: true }, function (curWindow) {
+    fn(curWindow.tabs);
+  });
+}
+
+/**
+ * Runs the given function with all user selected tabs in the current window.
+ *
+ * @param {Function} fn The function to run with all user selected tabs.
+ */
+function withSelectedTabs(fn) {
+  chrome.tabs.query({ currentWindow: true, highlighted: true }, (tabs) => {
+    fn(tabs);
+  });
+}
+
+chrome.commands.onCommand.addListener((command) => {
+  switch (command) {
+    case PIN_UNPIN_TAB:
+      withSelectedTabs((tabs) => {
+        togglePins(tabs);
+      });
+      break;
+    case UNPIN_ALL:
+      withAllTabs((tabs) => {
+        setTabsPinnedState(tabs, false);
+      });
+      break;
+    case PIN_ALL:
+      withAllTabs((tabs) => {
+        setTabsPinnedState(tabs, true);
+      });
+      break;
+    default:
+      break;
   }
 });
-


### PR DESCRIPTION
Fixes #8. Source code partly taken from my own project [Tab Shortcuts](https://github.com/2zqa/tab-shortcuts) (licenses are both MIT).

I also took the liberty of doing some refactorings, like using switch and replacing `function(tab)` with its syntactic sugar shorthand `(tab)`, but this turned out to be a near complete rewrite. I hope you don't mind.